### PR TITLE
test tf-nightly in the env with python 3.6, glibc 2.23 and gcc 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
-sudo: required
-dist: trusty
-language: python
-python:
-- '3.5'
+language: generic
+sudo: true
+cache:
+  directories:
+  - $HOME/.cache/jetware
 install:
-- pip install -r requirements.txt
+- wget -c -O $HOME/.cache/jetware/python36_glibc223_gcc54.tgz https://jetware.io/appliances/kvechera/python36_glibc223_gcc54-180219/download/installer:tgz
+- sudo mkdir /jet
+- sudo chown $USER /jet
+- tar xpzf $HOME/.cache/jetware/python36_glibc223_gcc54.tgz -C /jet
+- /jet/own/bin/run /jet/own/bin/fasten
+- /jet/enter pip install -r requirements.txt
 script:
-- pytest
+- |
+  /jet/enter <<_EOF_
+  pytest
+  _EOF_

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow
+tf-nightly
 pytest
 networkx
 toposort


### PR DESCRIPTION
The nightly builds require glibc 2.23 and libstdc++ from gcc 5, as they are in their building env Ubuntu 16.04. Here is the changes in trevis-ci's config, setting up the same environment on trevis' ubuntu 14.04.